### PR TITLE
Fix compile error. Set NeoPixelBus version to 2.6.6

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -18,7 +18,7 @@ framework = arduino
 upload_speed = 230400
 monitor_speed = 115200
 lib_deps =
-    makuna/NeoPixelBus@^2.5.7
+    makuna/NeoPixelBus@2.6.6
     bblanchon/ArduinoJson@^6.17.2
     links2004/WebSockets@^2.2.1
     adafruit/RTClib@^1.11.2


### PR DESCRIPTION
Sets the NeoPixelBus lib version to 2.6.6 to fix compile errors.